### PR TITLE
Make file url work in on modular-things.github.io

### DIFF
--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -8,7 +8,9 @@ import { authorizePort, initSerial, disconnectAll } from "./modularThingClient";
 
 export function init(state) {
   if (!navigator.serial) {
-    alert("🚨 Your browser doesn't seem to support the Web Serial API, which is required for Modular Things to be able to connect to hardware. You can still use the site to write code, but for full functionality, use Chrome or Edge version 89 or above.") 
+    alert(
+      "🚨 Your browser doesn't seem to support the Web Serial API, which is required for Modular Things to be able to connect to hardware. You can still use the site to write code, but for full functionality, use Chrome or Edge version 89 or above."
+    );
   }
 
   initSerial();
@@ -69,9 +71,15 @@ export function init(state) {
 
   const search = window.location.search;
   const file = new URLSearchParams(search).get("file");
+
+  const isProduction = window.location.hostname === "modular-things.github.io";
   if (file) {
     let file_url = file;
-    if (!file.startsWith("http")) file_url = `https://raw.githubusercontent.com/modular-things/modular-things/main/examples/${file}`; 
+    if (!file.startsWith("http"))
+      file_url = isProduction
+        ? `https://raw.githubusercontent.com/modular-things/modular-things/main/examples/${file}`
+        : `examples/${file}`;
+
     fetch(file_url).then(async (res) => {
       const text = await res.text();
 

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -7,8 +7,8 @@ import { runCode } from "./runCode";
 import { authorizePort, initSerial, disconnectAll } from "./modularThingClient";
 
 export function init(state) {
-  if(!navigator.serial){
-    // alert("🚨 Your browser doesn't seem to support the Web Serial API, which is required for Modular Things to be able to connect to hardware. You can still use the site to write code, but for full functionality, use Chrome or Edge version 89 or above.") 
+  if (!navigator.serial) {
+    alert("🚨 Your browser doesn't seem to support the Web Serial API, which is required for Modular Things to be able to connect to hardware. You can still use the site to write code, but for full functionality, use Chrome or Edge version 89 or above.") 
   }
 
   initSerial();
@@ -71,7 +71,7 @@ export function init(state) {
   const file = new URLSearchParams(search).get("file");
   if (file) {
     let file_url = file;
-    if (!file.startsWith("http")) file_url = `examples/${file}`;
+    if (!file.startsWith("http")) file_url = `https://raw.githubusercontent.com/modular-things/modular-things/main/examples/${file}`; 
     fetch(file_url).then(async (res) => {
       const text = await res.text();
 


### PR DESCRIPTION
I get a GitHub Pages 404 page when I try to load a file from the `examples` folder in this repo in production currently (works fine in development). This PR fixes that by using the raw link for the file when in production.

https://modular-things.github.io/modular-things/?file=haxidraw.js
<img width="600" alt="Screenshot 2023-04-28 at 3 33 14 PM" src="https://user-images.githubusercontent.com/72365100/235244452-d0357fb1-3d69-45c6-a9b2-4b9745662994.png">
